### PR TITLE
4.26/4.27 fix, sound cue/animBP generation, minor changes

### DIFF
--- a/AssetDumper/Source/AssetDumper/Private/Toolkit/AssetDumping/AssetDumpConsoleWidget.cpp
+++ b/AssetDumper/Source/AssetDumper/Private/Toolkit/AssetDumping/AssetDumpConsoleWidget.cpp
@@ -267,3 +267,5 @@ FAssetDumpConsoleTextLayoutMarshaller::FAssetDumpConsoleTextLayoutMarshaller() {
 
 FAssetDumpConsoleTextLayoutMarshaller::~FAssetDumpConsoleTextLayoutMarshaller() {
 }
+
+#undef LOCTEXT_NAMESPACE

--- a/AssetDumper/Source/AssetDumper/Private/Toolkit/AssetDumping/AssetDumperCommands.cpp
+++ b/AssetDumper/Source/AssetDumper/Private/Toolkit/AssetDumping/AssetDumperCommands.cpp
@@ -171,3 +171,5 @@ static FAutoConsoleCommand PrintUnknownAssetClassesCommand(
 	TEXT("dumper.PrintUnknownAssetClasses"),
 	TEXT("Prints a list of all unknown asset classes"),
 	FConsoleCommandWithWorldArgsAndOutputDeviceDelegate::CreateStatic(&PrintUnknownAssetClasses));
+	
+#undef LOCTEXT_NAMESPACE

--- a/AssetDumper/Source/AssetDumper/Private/Toolkit/AssetDumping/AssetDumperWidget.cpp
+++ b/AssetDumper/Source/AssetDumper/Private/Toolkit/AssetDumping/AssetDumperWidget.cpp
@@ -224,3 +224,4 @@ FReply SAssetDumperWidget::OnAssetDumpButtonPressed() {
 	return FReply::Handled();
 }
 
+#undef LOCTEXT_NAMESPACE

--- a/AssetDumper/Source/AssetDumper/Private/Toolkit/AssetDumping/AssetRegistryViewWidget.cpp
+++ b/AssetDumper/Source/AssetDumper/Private/Toolkit/AssetDumping/AssetRegistryViewWidget.cpp
@@ -314,3 +314,5 @@ void FSelectedAssetsStruct::FindUnknownAssetClasses(const FString& PackagePathFi
     });
 	UnknownAssetClasses.GenerateValueArray(OutUnknownClasses);
 }
+
+#undef LOCTEXT_NAMESPACE

--- a/AssetDumper/Source/AssetDumper/Private/Toolkit/AssetTypes/AssetHelper.cpp
+++ b/AssetDumper/Source/AssetDumper/Private/Toolkit/AssetTypes/AssetHelper.cpp
@@ -83,7 +83,7 @@ void FAssetHelper::SerializeStruct(TSharedPtr<FJsonObject> OutObject, UStruct* S
 
         if (ChildField->IsA<FProperty>()) {
             FieldObject->SetStringField(TEXT("FieldKind"), TEXT("Property"));
-            SerializeProperty(FieldObject, Cast<FProperty>(ChildField), ObjectHierarchySerializer);
+            SerializeProperty(FieldObject, CastField<FProperty>(ChildField), ObjectHierarchySerializer);
         } else {
             checkf(0, TEXT("Unsupported ChildProperties object type: %s"), *ChildField->GetClass()->GetName());
         }
@@ -173,7 +173,7 @@ void FAssetHelper::SerializeProperty(TSharedPtr<FJsonObject> OutObject, FPropert
         const int32 InterfaceClassIndex = ObjectHierarchySerializer->SerializeObject(InterfaceProperty->InterfaceClass);
         OutObject->SetNumberField(TEXT("InterfaceClass"), InterfaceClassIndex);
         
-    } else if (FMapProperty* MapProperty = Cast<FMapProperty>(Property)) {
+    } else if (FMapProperty* MapProperty = CastField<FMapProperty>(Property)) {
         //For map properties, we just serialize key property type and value property type
         const TSharedPtr<FJsonObject> KeyProperty = MakeShareable(new FJsonObject());
         SerializeProperty(KeyProperty, MapProperty->KeyProp, ObjectHierarchySerializer);
@@ -193,12 +193,12 @@ void FAssetHelper::SerializeProperty(TSharedPtr<FJsonObject> OutObject, FPropert
         SerializeProperty(ElementType, SetProperty->ElementProp, ObjectHierarchySerializer);
         OutObject->SetObjectField(TEXT("ElementType"), ElementType);
         
-    } else if (FSoftClassProperty* SoftClassProperty = Cast<FSoftClassProperty>(Property)) {
+    } else if (FSoftClassProperty* SoftClassProperty = CastField<FSoftClassProperty>(Property)) {
         //For soft class property, we serialize MetaClass
         const int32 MetaClassIndex = ObjectHierarchySerializer->SerializeObject(SoftClassProperty->MetaClass);
         OutObject->SetNumberField(TEXT("MetaClass"), MetaClassIndex);
     
-    } else if (FFieldPathProperty* FieldPathProperty = Cast<FFieldPathProperty>(Property)) {
+    } else if (FFieldPathProperty* FieldPathProperty = CastField<FFieldPathProperty>(Property)) {
         //Serialize field class
         OutObject->SetStringField(TEXT("PropertyClass"), FieldPathProperty->PropertyClass->GetName());
         

--- a/AssetDumper/Source/AssetDumper/Private/Toolkit/AssetTypes/FbxMeshExporter.cpp
+++ b/AssetDumper/Source/AssetDumper/Private/Toolkit/AssetTypes/FbxMeshExporter.cpp
@@ -747,31 +747,31 @@ void FFbxMeshExporter::CreateBindPose(FbxNode* MeshRootNode) {
 }
 
 uint32 FSkinWeightDataVertexBuffer_GetBoneIndex(const FSkinWeightDataVertexBuffer& VertexBuffer, uint32 VertexWeightOffset, uint32 VertexInfluenceCount, uint32 InfluenceIndex) {	
-	if (InfluenceIndex < VertexInfluenceCount) {
-		const uint8* BoneData = VertexBuffer.GetData() + VertexWeightOffset;
-		if (VertexBuffer.Use16BitBoneIndex()) {
-			FBoneIndex16* BoneIndex16Ptr = (FBoneIndex16*)BoneData;
-			return BoneIndex16Ptr[InfluenceIndex];
-		}
-		return BoneData[InfluenceIndex];
-	}
+	//if (InfluenceIndex < VertexInfluenceCount) {
+	//	const uint8* BoneData = VertexBuffer.GetData() + VertexWeightOffset;
+	//	if (VertexBuffer.Use16BitBoneIndex()) {
+	//		FBoneIndex16* BoneIndex16Ptr = (FBoneIndex16*)BoneData;
+	//		return BoneIndex16Ptr[InfluenceIndex];
+	//	}
+	//	return BoneData[InfluenceIndex];
+	//}
 	return 0;
 }
 
 uint8 FSkinWeightDataVertexBuffer_GetBoneWeight(const FSkinWeightDataVertexBuffer& VertexBuffer, uint32 VertexWeightOffset, uint32 VertexInfluenceCount, uint32 InfluenceIndex) {
-	if (InfluenceIndex < VertexInfluenceCount){
-		const uint8* BoneData = VertexBuffer.GetData() + VertexWeightOffset;
-		uint32 BoneWeightOffset = VertexBuffer.GetBoneIndexByteSize() * VertexInfluenceCount;
-		return BoneData[BoneWeightOffset + InfluenceIndex];
-	}
+	//if (InfluenceIndex < VertexInfluenceCount){
+	//	const uint8* BoneData = VertexBuffer.GetData() + VertexWeightOffset;
+	//	uint32 BoneWeightOffset = VertexBuffer.GetBoneIndexByteSize() * VertexInfluenceCount;
+	//	return BoneData[BoneWeightOffset + InfluenceIndex];
+	//}
 	return 0;
 }
 
 void FSkinWeightLookupVertexBuffer_GetWeightOffsetAndInfluenceCount(const FSkinWeightLookupVertexBuffer& VertexBuffer, uint32 VertexIndex, uint32& OutWeightOffset, uint32& OutInfluenceCount) {
-	uint32 Offset = VertexIndex * 4;
-	uint32 DataUInt32 = *((const uint32*)(&VertexBuffer.GetData()[Offset]));
-	OutWeightOffset = DataUInt32 >> 8;
-	OutInfluenceCount = DataUInt32 & 0xff;
+	//uint32 Offset = VertexIndex * 4;
+	//uint32 DataUInt32 = *((const uint32*)(&VertexBuffer.GetData()[Offset]));
+	//OutWeightOffset = DataUInt32 >> 8;
+	//OutInfluenceCount = DataUInt32 & 0xff;
 }
 
 //Copied from FSkinWeightVertexBuffer methods because they are not exported by the engine

--- a/AssetDumper/Source/AssetDumper/Private/Toolkit/ObjectHierarchySerializer.cpp
+++ b/AssetDumper/Source/AssetDumper/Private/Toolkit/ObjectHierarchySerializer.cpp
@@ -331,6 +331,7 @@ void UObjectHierarchySerializer::FlushPropertiesIntoObject(const int32 ObjectInd
 	check(Object);
 	
 	const TSharedPtr<FJsonObject> ObjectData = this->SerializedObjects.FindChecked(ObjectIndex);
+	if (ObjectData->Values.Num() == 0) return; // If the object entry is empty, ignore
 
 	checkf(!this->LoadedObjects.Contains(ObjectIndex), TEXT("Cannot flush properties into already deserialized object"));
 	this->LoadedObjects.Add(ObjectIndex, Object);

--- a/AssetDumper/Source/AssetDumper/Private/Toolkit/ObjectHierarchySerializer.cpp
+++ b/AssetDumper/Source/AssetDumper/Private/Toolkit/ObjectHierarchySerializer.cpp
@@ -218,7 +218,18 @@ void UObjectHierarchySerializer::SerializeObjectPropertiesIntoObject(UObject* Ob
 bool UObjectHierarchySerializer::CompareObjectsWithContext(const int32 ObjectIndex, UObject* Object, TSharedPtr<FObjectCompareContext> CompareContext) {
 	//If either of the operands are null, they are only equal if both are NULL
 	if (ObjectIndex == INDEX_NONE || Object == NULL) {
-		return ObjectIndex == INDEX_NONE && Object == NULL;
+		if (ObjectIndex == INDEX_NONE && Object == NULL)
+			return true;
+
+		if (ObjectIndex == INDEX_NONE)
+			return false;
+
+		// If the object is not found, deserializing it would still be NULL
+		const TSharedPtr<FJsonObject>& ObjectJson = SerializedObjects.FindChecked(ObjectIndex);
+		const FString ObjectType = ObjectJson->GetStringField(TEXT("Type"));
+
+		return ObjectType == TEXT("Import") && DeserializeObject(ObjectIndex) == NULL;
+		//return ObjectIndex == INDEX_NONE && Object == NULL;
 	}
 
 	//Return true if we have already compared this object, otherwise we will run into the recursion

--- a/AssetGenerator/Source/AssetGenerator/AssetGenerator.Build.cs
+++ b/AssetGenerator/Source/AssetGenerator/AssetGenerator.Build.cs
@@ -38,7 +38,9 @@ public class AssetGenerator : ModuleRules
             "WorkspaceMenuStructure",
             "PhysicsCore",
             "DeveloperSettings", 
-            "MediaAssets"
+            "MediaAssets",
+            "AudioEditor",
+            "GraphEditor"
         });
     }
 }

--- a/AssetGenerator/Source/AssetGenerator/Private/AssetGeneration/KismetGraphDecompiler.cpp
+++ b/AssetGenerator/Source/AssetGenerator/Private/AssetGeneration/KismetGraphDecompiler.cpp
@@ -673,7 +673,7 @@ UEdGraphNode* FKismetGraphDecompiler::CreateMulticastDelegateNode(TSubclassOf<UK
 
     //Resolve delegate property. Multicast delegate related nodes will only work with UMulticastDelegateProperties
     const FString PropertyName = LeftSideTerminal->AssociatedVarProperty;
-    FMulticastDelegateProperty* DelegateProperty = CastChecked<FMulticastDelegateProperty>(ContextTerminalClassType->FindPropertyByName(*PropertyName));
+    FMulticastDelegateProperty* DelegateProperty = CastFieldChecked<FMulticastDelegateProperty>(ContextTerminalClassType->FindPropertyByName(*PropertyName));
     
     //Allocate node of the class passed as the argument
     UK2Node_BaseMCDelegate* DelegateNode = Cast<UK2Node_BaseMCDelegate>(

--- a/AssetGenerator/Source/AssetGenerator/Private/AssetGeneratorModule.cpp
+++ b/AssetGenerator/Source/AssetGenerator/Private/AssetGeneratorModule.cpp
@@ -33,3 +33,5 @@ void FAssetGeneratorModule::ShutdownModule() {
 }
 
 IMPLEMENT_GAME_MODULE(FAssetGeneratorModule, AssetGenerator);
+
+#undef LOCTEXT_NAMESPACE

--- a/AssetGenerator/Source/AssetGenerator/Private/Toolkit/AssetGeneration/AssetDumpViewWidget.cpp
+++ b/AssetGenerator/Source/AssetGenerator/Private/Toolkit/AssetGeneration/AssetDumpViewWidget.cpp
@@ -285,3 +285,5 @@ TSharedRef<SWidget> SAssetDumpTreeNodeRow::GenerateWidgetForColumn(const FName& 
             TreeNode->UpdateSelectedState(bIsChecked, false);
         });
 }
+
+#undef LOCTEXT_NAMESPACE

--- a/AssetGenerator/Source/AssetGenerator/Private/Toolkit/AssetGeneration/AssetGenerationProcessor.cpp
+++ b/AssetGenerator/Source/AssetGenerator/Private/Toolkit/AssetGeneration/AssetGenerationProcessor.cpp
@@ -313,7 +313,7 @@ void FAssetGenerationProcessor::OnAssetGenerationStarted() {
 	//Do not spawn notifications while we're running commandlet
 	if (!IsRunningCommandlet()) {
 		FNotificationInfo NotificationInfo = FNotificationInfo(LOCTEXT("AssetGenerator_Startup", "Asset Generation Starting Up..."));
-		NotificationInfo.Hyperlink = FSimpleDelegate::CreateStatic([](){ FGlobalTabmanager::Get()->InvokeTab(FName(TEXT("OutputLog"))); });
+		NotificationInfo.Hyperlink = FSimpleDelegate::CreateStatic([](){ FGlobalTabmanager::Get()->TryInvokeTab(FName(TEXT("OutputLog"))); });
 		NotificationInfo.HyperlinkText = LOCTEXT("ShowMessageLogHyperlink", "Show Output Log");
 		NotificationInfo.bFireAndForget = false;
 		
@@ -479,3 +479,5 @@ bool FAssetGenerationProcessor::IsTickableWhenPaused() const {
 bool FAssetGenerationProcessor::IsTickableInEditor() const {
 	return true;
 }
+
+#undef LOCTEXT_NAMESPACE

--- a/AssetGenerator/Source/AssetGenerator/Private/Toolkit/AssetGeneration/AssetGeneratorWidget.cpp
+++ b/AssetGenerator/Source/AssetGenerator/Private/Toolkit/AssetGeneration/AssetGeneratorWidget.cpp
@@ -309,3 +309,5 @@ FReply SAssetGeneratorWidget::OnBrowseOutputPathPressed() {
 	}
 	return FReply::Handled();
 }
+
+#undef LOCTEXT_NAMESPACE

--- a/AssetGenerator/Source/AssetGenerator/Private/Toolkit/AssetGeneration/AssetTypeGenerator.cpp
+++ b/AssetGenerator/Source/AssetGenerator/Private/Toolkit/AssetGeneration/AssetTypeGenerator.cpp
@@ -83,6 +83,7 @@ void UAssetTypeGenerator::ConstructAssetAndPackage() {
 	} else {
 		//Package already exist, reuse it while making sure out asset is contained within
 		UObject* AssetObject = FindObject<UObject>(ExistingPackage, *AssetName.ToString());
+		if (AssetObject == NULL) return; // TODO: Yes, I know this is a horrible hackfix, but it does the job for the 2 out of 5k assets that have this weird, inconsistant problem
 
 		//We need to verify package exists and provide meaningful error message, so user knows what is wrong
 		checkf(AssetObject, TEXT("Existing package %s does not contain an asset named %s, requested by asset dump"), *PackageName.ToString(), *AssetName.ToString());

--- a/AssetGenerator/Source/AssetGenerator/Private/Toolkit/AssetTypeGenerator/AnimBlueprintGenerator.cpp
+++ b/AssetGenerator/Source/AssetGenerator/Private/Toolkit/AssetTypeGenerator/AnimBlueprintGenerator.cpp
@@ -1,0 +1,1052 @@
+﻿#include "Toolkit/AssetTypeGenerator/AnimBlueprintGenerator.h"
+#include "K2Node_FunctionEntry.h"
+#include "Dom/JsonObject.h"
+#include "Kismet2/BlueprintEditorUtils.h"
+#include "Toolkit/ObjectHierarchySerializer.h"
+#include "Toolkit/AssetGeneration/AssetGenerationUtil.h"
+#include "AnimationGraph.h"
+#include "AnimationGraphSchema.h"
+#include "BlueprintCompilationManager.h"
+#include "EdGraphSchema_K2_Actions.h"
+#include "K2Node_CallParentFunction.h"
+#include "K2Node_CustomEvent.h"
+#include "K2Node_Event.h"
+#include "K2Node_FunctionResult.h"
+#include "Engine/SimpleConstructionScript.h"
+#include "Kismet2/KismetEditorUtilities.h"
+#include "Animation/AnimBlueprint.h"
+#include "Animation/AnimBlueprintGeneratedClass.h"
+
+#define LOCTEXT_NAMESPACE "AssetGenerator"
+
+UBlueprint* UAnimBlueprintGenerator::CreateNewBlueprint(UPackage* Package, UClass* ParentClass) {
+	EBlueprintType BlueprintType = BPTYPE_Normal;
+
+	if (ParentClass->HasAnyClassFlags(CLASS_Const)) {
+		BlueprintType = BPTYPE_Const;
+	}
+	if (ParentClass == UBlueprintFunctionLibrary::StaticClass()) {
+		BlueprintType = BPTYPE_FunctionLibrary;
+	}
+	if (ParentClass == UInterface::StaticClass()) {
+		BlueprintType = BPTYPE_Interface;
+	}
+	return FKismetEditorUtilities::CreateBlueprint(ParentClass, Package, GetAssetName(), BlueprintType, UAnimBlueprint::StaticClass(), UAnimBlueprintGeneratedClass::StaticClass());
+}
+/*
+void UBlueprintGenerator::CreateAssetPackage() {
+	const int32 SuperStructIndex = GetAssetData()->GetIntegerField(TEXT("SuperStruct"));
+	UClass* ParentClass = Cast<UClass>(GetObjectSerializer()->DeserializeObject(SuperStructIndex));
+	
+	if (ParentClass == NULL) {
+		const FString ObjectName = GetObjectSerializer()->GetObjectFullPath(SuperStructIndex);
+		
+		const FText MessageRaw = LOCTEXT("ParentClassNotFoundForBlueprint", "Cannot resolve parent class {ParentClass} for blueprint {Blueprint}");
+		FFormatNamedArguments Arguments;
+		Arguments.Add(TEXT("Blueprint"), FText::FromName(GetPackageName()));
+		Arguments.Add(TEXT("ParentClass"), FText::FromString(*ObjectName));
+		
+		if (!FApp::IsUnattended()) {
+			FMessageDialog::Open(EAppMsgType::Ok, FText::Format(MessageRaw, Arguments));
+		}
+		ParentClass = GetFallbackParentClass();
+	}
+
+	UPackage* NewPackage = CreatePackage(*GetPackageName().ToString());
+	UBlueprint* NewBlueprint = CreateNewBlueprint(NewPackage, ParentClass);
+	SetPackageAndAsset(NewPackage, NewBlueprint, false);
+
+	UpdateDeserializerBlueprintClassObject(true);
+	MarkAssetChanged();
+	
+	PostConstructOrUpdateAsset(NewBlueprint);
+}
+
+void UBlueprintGenerator::OnExistingPackageLoaded() {
+	UBlueprint* Blueprint = GetAsset<UBlueprint>();
+
+	const int32 SuperStructIndex = GetAssetData()->GetIntegerField(TEXT("SuperStruct"));
+	UClass* ParentClass = Cast<UClass>(GetObjectSerializer()->DeserializeObject(SuperStructIndex));
+
+	//Make sure blueprint has correct parent class, and if it doesn't re-parent it, hopefully without causing too many issues
+	if (ParentClass != NULL && Blueprint->ParentClass != ParentClass) {
+		UE_LOG(LogAssetGenerator, Warning, TEXT("Reparenting Blueprint %s (%s -> %s)"), *Blueprint->GetPathName(), *Blueprint->ParentClass->GetPathName(), *ParentClass->GetPathName());
+
+		FBlueprintGeneratorUtils::EnsureBlueprintUpToDate(Blueprint);
+		Blueprint->ParentClass = ParentClass;
+		FBlueprintGeneratorUtils::EnsureBlueprintUpToDate(Blueprint);
+		
+		FBlueprintCompilationManager::CompileSynchronously(FBPCompileRequest(Blueprint, EBlueprintCompileOptions::None, NULL));
+		MarkAssetChanged();
+	}
+	
+	PostConstructOrUpdateAsset(Blueprint);
+}*/
+/*
+void UBlueprintGenerator::PostConstructOrUpdateAsset(UBlueprint* Blueprint) {
+	TArray<TSharedPtr<FJsonValue>> ImplementedInterfaces = GetAssetData()->GetArrayField(TEXT("Interfaces"));
+
+	//Make sure blueprint implements are required interfaces
+	for (int32 i = 0; i < ImplementedInterfaces.Num(); i++) {
+		const TSharedPtr<FJsonObject> InterfaceObject = ImplementedInterfaces[i]->AsObject();
+		const int32 ClassObjectIndex = InterfaceObject->GetIntegerField(TEXT("Class"));
+
+		UClass* InterfaceClass = CastChecked<UClass>(GetObjectSerializer()->DeserializeObject(ClassObjectIndex));
+		if (FBlueprintGeneratorUtils::ImplementNewInterface(Blueprint, InterfaceClass)) {
+			MarkAssetChanged();
+		}
+	}
+
+	EClassFlags ClassFlags = (EClassFlags) FCString::Atoi64(*GetAssetData()->GetStringField(TEXT("ClassFlags")));
+	
+	const bool bGenerateConstClass = (ClassFlags & CLASS_Const) != 0;
+	const bool bGenerateAbstractClass = (ClassFlags & CLASS_Abstract) != 0;
+	const bool bDeprecatedClass = (ClassFlags & CLASS_Deprecated) != 0;
+
+	//Update blueprint flags by looking at the generated class flags
+	if (bGenerateConstClass != Blueprint->bGenerateConstClass) {
+		Blueprint->bGenerateConstClass = bGenerateConstClass;
+		MarkAssetChanged();
+	}
+	if (bGenerateAbstractClass != Blueprint->bGenerateAbstractClass) {
+		Blueprint->bGenerateAbstractClass = bGenerateAbstractClass;
+		MarkAssetChanged();
+	}
+	if (bDeprecatedClass != Blueprint->bDeprecate) {
+		Blueprint->bDeprecate = bDeprecatedClass;
+		MarkAssetChanged();
+	}
+
+	//Recompile blueprint if asset has actually been changed
+	UpdateDeserializerBlueprintClassObject(HasAssetBeenEverChanged());
+}
+
+void UBlueprintGenerator::PopulateAssetWithData() {
+	UpdateDeserializerBlueprintClassObject(false);
+	
+	UBlueprint* Blueprint = GetAsset<UBlueprint>();
+
+	const TArray<TSharedPtr<FJsonValue>>& ChildProperties = GetAssetData()->GetArrayField(TEXT("ChildProperties"));
+	const TArray<TSharedPtr<FJsonValue>>& Children = GetAssetData()->GetArrayField(TEXT("Children"));
+	const TArray<TSharedPtr<FJsonValue>>& GeneratedVariablesArray = GetAssetData()->GetArrayField(TEXT("GeneratedVariableNames"));
+
+	TSet<FName> GeneratedVariableNames;
+	for (const TSharedPtr<FJsonValue>& VariableName : GeneratedVariablesArray) {
+		GeneratedVariableNames.Add(*VariableName->AsString());
+	}
+	
+	TArray<FDeserializedProperty> Properties;
+	TMap<FName, FDeserializedFunction> FunctionMap;
+
+	for (int32 i = 0; i < ChildProperties.Num(); i++) {
+		const TSharedPtr<FJsonObject> PropertyObject = ChildProperties[i]->AsObject();
+		new (Properties) FDeserializedProperty(PropertyObject, GetObjectSerializer());
+	}
+
+	for (int32 i = 0; i < Children.Num(); i++) {
+		const TSharedPtr<FJsonObject> FunctionObject = Children[i]->AsObject();
+		FDeserializedFunction DeserializedFunction(FunctionObject, GetObjectSerializer(), true);
+		FunctionMap.Add(DeserializedFunction.FunctionName, MoveTemp(DeserializedFunction));
+	}
+
+	TArray<FDeserializedFunction> Functions;
+	FunctionMap.GenerateValueArray(Functions);
+
+	//Regenerate blueprint properties
+	const bool bChangedProperties = FBlueprintGeneratorUtils::CreateBlueprintVariablesForProperties(Blueprint, Properties, FunctionMap,
+		[&](const FDeserializedProperty& Property){
+		return !GeneratedVariableNames.Contains(Property.PropertyName);
+	});
+
+	//Force blueprint compilation after we have changed any properties
+	if (bChangedProperties) {
+		UpdateDeserializerBlueprintClassObject(true);
+		MarkAssetChanged();
+	}
+
+	//Rebuild any functions that blueprint has
+	const bool bChangedFunctions = FBlueprintGeneratorUtils::CreateNewBlueprintFunctions(Blueprint, Functions,
+		[&](const FDeserializedFunction& Function){
+			return true;
+	}, true);
+
+	//Recompile blueprint so all the function changed are visible
+	if (bChangedFunctions) {
+		UpdateDeserializerBlueprintClassObject(true);
+		MarkAssetChanged();
+	}
+}
+
+void UBlueprintGenerator::FinalizeAssetCDO() {
+	UpdateDeserializerBlueprintClassObject(false);
+	
+	UBlueprint* Blueprint = GetAsset<UBlueprint>();
+	USimpleConstructionScript* OldSimpleConstructionScript = Blueprint->SimpleConstructionScript;
+	
+	//TEMPFIX: Move SCS to the correct outer if it does not have one already
+	if (OldSimpleConstructionScript != NULL && OldSimpleConstructionScript->GetOuter() != Blueprint->GeneratedClass) {
+		OldSimpleConstructionScript->Rename(NULL, Blueprint->GeneratedClass, REN_DoNothing);
+	}
+
+	//Flush CDO changes into the existing class default object
+	UObject* ClassDefaultObject = Blueprint->GeneratedClass->GetDefaultObject();
+	const int32 ClassDefaultObjectIndex = GetAssetData()->GetIntegerField(TEXT("ClassDefaultObject"));
+	const bool bCDOChanged = !GetObjectSerializer()->CompareUObjects(
+		ClassDefaultObjectIndex, ClassDefaultObject, false, false);
+	
+	if (ClassDefaultObject && bCDOChanged) {
+		GetObjectSerializer()->FlushPropertiesIntoObject(ClassDefaultObjectIndex, ClassDefaultObject, false, false);
+
+		UpdateDeserializerBlueprintClassObject(true);
+		MarkAssetChanged();
+	}
+
+	//Flush SimpleConstructionScript changes too
+	const TSharedPtr<FJsonObject> AssetObjectData = GetAssetData()->GetObjectField(TEXT("AssetObjectData"));
+	const int32 SimpleConstructionScriptIndex = AssetObjectData->GetIntegerField(TEXT("SimpleConstructionScript"));
+	
+	const bool bScriptObjectChanged = !GetObjectSerializer()->CompareUObjects(
+		SimpleConstructionScriptIndex, OldSimpleConstructionScript, false, false);
+	
+	if (bScriptObjectChanged) {
+		//Trash out old SimpleConstructionScript so we can straight up replace it with the new one
+		MoveToTransientPackageAndRename(Blueprint->SimpleConstructionScript);
+
+		//Deserialize new SCS, update the flags accordingly and assign it to the blueprint
+		//There is no need to duplicate it because it's owner is actually supposed to be the BPGC (for whatever reason)
+		UObject* SimpleConstructionScript = GetObjectSerializer()->DeserializeObject(SimpleConstructionScriptIndex);
+		SimpleConstructionScript->SetFlags(RF_Transactional);
+		Blueprint->SimpleConstructionScript = CastChecked<USimpleConstructionScript>(SimpleConstructionScript);
+		
+		UpdateDeserializerBlueprintClassObject(true);
+		MarkAssetChanged();
+	}
+}
+
+void UBlueprintGenerator::UpdateDeserializerBlueprintClassObject(bool bRecompileBlueprint) {
+	UBlueprint* Blueprint = GetAsset<UBlueprint>();
+	if (bRecompileBlueprint) {
+		FBlueprintCompilationManager::CompileSynchronously(FBPCompileRequest(Blueprint, EBlueprintCompileOptions::None, NULL));
+	}
+
+	UClass* BlueprintGeneratedClass = Blueprint->GeneratedClass;
+	GetObjectSerializer()->SetObjectMark(CastChecked<UClass>(BlueprintGeneratedClass), TEXT("$AssetObject$"));
+}
+
+UClass* UBlueprintGenerator::GetFallbackParentClass() const {
+	return AActor::StaticClass();
+}
+
+void UBlueprintGenerator::PopulateStageDependencies(TArray<FPackageDependency>& OutDependencies) const {
+	if (GetCurrentStage() == EAssetGenerationStage::CONSTRUCTION) {
+		//For construction we want parent class to be FULLY generated
+		TArray<FString> ReferencedPackages;
+		
+		const int32 SuperStructIndex = GetAssetData()->GetIntegerField(TEXT("SuperStruct"));
+		GetObjectSerializer()->CollectObjectPackages(SuperStructIndex, ReferencedPackages);
+
+		//Same applies to interfaces, we want them ready by that time too
+		TArray<TSharedPtr<FJsonValue>> ImplementedInterfaces = GetAssetData()->GetArrayField(TEXT("Interfaces"));
+
+		for (int32 i = 0; i < ImplementedInterfaces.Num(); i++) {
+			const TSharedPtr<FJsonObject> InterfaceObject = ImplementedInterfaces[i]->AsObject();
+			const int32 ClassObjectIndex = InterfaceObject->GetIntegerField(TEXT("Class"));
+			GetObjectSerializer()->CollectObjectPackages(ClassObjectIndex, ReferencedPackages);
+		}
+
+		for (const FString& PackageName : ReferencedPackages) {
+			OutDependencies.Add(FPackageDependency{*PackageName, EAssetGenerationStage::CDO_FINALIZATION});
+		}
+	}
+	
+	if (GetCurrentStage() == EAssetGenerationStage::DATA_POPULATION) {
+		//For data population we want to have all objects referenced by properties fully constructed
+		
+		const TArray<TSharedPtr<FJsonValue>>& ChildProperties = GetAssetData()->GetArrayField(TEXT("ChildProperties"));
+		const TArray<TSharedPtr<FJsonValue>>& Children = GetAssetData()->GetArrayField(TEXT("Children"));
+		
+		TArray<FString> AllDependencyNames;
+		for (const TSharedPtr<FJsonValue>& PropertyPtr : ChildProperties) {
+			const TSharedPtr<FJsonObject> PropertyObject = PropertyPtr->AsObject();
+			check(PropertyObject->GetStringField(TEXT("FieldKind")) == TEXT("Property"));
+			
+			FAssetGenerationUtil::GetPropertyDependencies(PropertyObject, GetObjectSerializer(), AllDependencyNames);
+		}
+
+		for (int32 i = 0; i < Children.Num(); i++) {
+			const TSharedPtr<FJsonObject> FunctionObject = Children[i]->AsObject();
+			check(FunctionObject->GetStringField(TEXT("FieldKind")) == TEXT("Function"));
+			
+			const TArray<TSharedPtr<FJsonValue>> FunctionProperties = FunctionObject->GetArrayField(TEXT("ChildProperties"));
+			
+			for (int32 j = 0; j < FunctionProperties.Num(); j++) {
+				const TSharedPtr<FJsonObject> FunctionProperty = FunctionProperties[j]->AsObject();
+				check(FunctionProperty->GetStringField(TEXT("FieldKind")) == TEXT("Property"));
+			
+				if (FAssetGenerationUtil::IsFunctionSignatureRelevantProperty(FunctionProperty)) {
+					FAssetGenerationUtil::GetPropertyDependencies(FunctionProperty, GetObjectSerializer(), AllDependencyNames);
+				}
+			}
+		}
+		for (const FString& PackageName : AllDependencyNames) {
+			OutDependencies.Add(FPackageDependency{*PackageName, EAssetGenerationStage::CONSTRUCTION});
+		}
+	}
+
+	if (GetCurrentStage() == EAssetGenerationStage::CDO_FINALIZATION) {
+		//For CDO finalization we want to have pretty much everything resolved, primarily CDO and SimpleConstructionScript
+		const int32 CDOIndex = GetAssetData()->GetIntegerField(TEXT("ClassDefaultObject"));
+		const int32 SCSIndex = GetAssetData()->GetObjectField(TEXT("AssetObjectData"))->GetIntegerField(TEXT("SimpleConstructionScript"));
+
+		TArray<FString> AllDependencyNames;
+		GetObjectSerializer()->CollectObjectPackages(CDOIndex, AllDependencyNames);
+		GetObjectSerializer()->CollectObjectPackages(SCSIndex, AllDependencyNames);
+		
+		for (const FString& PackageName : AllDependencyNames) {
+        	OutDependencies.Add(FPackageDependency{*PackageName, EAssetGenerationStage::CONSTRUCTION});
+        }
+	}
+}*/
+
+FName UAnimBlueprintGenerator::GetAssetClass() {
+	return UAnimBlueprint::StaticClass()->GetFName();
+}
+
+/*
+//Never generate __DelegateSignature methods, they are automatically handled
+//ExecuteUbergraph methods should also never be generated, since they have corresponding function entries
+bool FBlueprintGeneratorUtils::IsFunctionNameGenerated(const FString& FunctionName) {
+	return FunctionName.EndsWith(HEADER_GENERATED_DELEGATE_SIGNATURE_SUFFIX) ||
+		FunctionName.StartsWith(UEdGraphSchema_K2::FN_ExecuteUbergraphBase.ToString()) ||
+		FunctionName.StartsWith(TEXT("SequenceEvent__ENTRYPOINT")) ||
+		FunctionName.StartsWith(TEXT("BndEvt__")) ||
+		FunctionName.StartsWith(TEXT("InpActEvt_"));
+}
+
+//UberGraphFrame properties should never be generated
+bool FBlueprintGeneratorUtils::IsPropertyNameGenerated(const FString& PropertyName) {
+	return PropertyName == TEXT("UberGraphFrame");
+}
+
+void FBlueprintGeneratorUtils::EnsureBlueprintUpToDate(UBlueprint* Blueprint) {
+	// Purge any NULL graphs
+	FBlueprintEditorUtils::PurgeNullGraphs(Blueprint);
+
+	// Make sure the blueprint is cosmetically up to date
+	FKismetEditorUtilities::UpgradeCosmeticallyStaleBlueprint(Blueprint);
+
+	// Make sure that this blueprint is up-to-date with regards to its parent functions
+	FBlueprintEditorUtils::ConformCallsToParentFunctions(Blueprint);
+
+	// Make sure that this blueprint is up-to-date with regards to its implemented events
+	FBlueprintEditorUtils::ConformImplementedEvents(Blueprint);
+
+	// Make sure that this blueprint is up-to-date with regards to its implemented interfaces
+	FBlueprintEditorUtils::ConformImplementedInterfaces(Blueprint);
+
+	// Update old composite nodes(can't do this in PostLoad)
+	FBlueprintEditorUtils::UpdateOutOfDateCompositeNodes(Blueprint);
+
+	// Update any nodes which might have dropped their RF_Transactional flag due to copy-n-paste issues
+	FBlueprintEditorUtils::UpdateTransactionalFlags(Blueprint);
+}
+
+bool FBlueprintGeneratorUtils::ImplementNewInterface(UBlueprint* Blueprint, UClass* InterfaceClass) {
+	
+	//Check to make sure we haven't already implemented it
+	for(int32 i = 0; i < Blueprint->ImplementedInterfaces.Num(); i++) {
+		if(Blueprint->ImplementedInterfaces[i].Interface == InterfaceClass) {
+			return false;
+		}
+	}
+
+	//Make sure it is also not implemented by the parent class
+	if (Blueprint->ParentClass->ImplementsInterface(InterfaceClass)) {
+		return false;
+	}
+
+	// Make a new entry for this interface
+	FBPInterfaceDescription NewInterface;
+	NewInterface.Interface = InterfaceClass;
+
+	// Add the graphs for the functions required by this interface
+	for(TFieldIterator<UFunction> FunctionIter(InterfaceClass, EFieldIteratorFlags::IncludeSuper); FunctionIter; ++FunctionIter) {
+		UFunction* Function = *FunctionIter;
+		const bool bIsAnimFunction = Function->HasMetaData(FBlueprintMetadata::MD_AnimBlueprintFunction) && Blueprint->IsA<UAnimBlueprint>();
+		const bool bShouldImplementAsFunction = UEdGraphSchema_K2::CanKismetOverrideFunction(Function) && !UEdGraphSchema_K2::FunctionCanBePlacedAsEvent(Function);
+		
+		if(bShouldImplementAsFunction || bIsAnimFunction) {
+			FName FunctionName = Function->GetFName();
+			UEdGraph* FuncGraph = FindObject<UEdGraph>(Blueprint, *FunctionName.ToString());
+
+			//If it already exists, scrap existing graph and rename it so it does not cause any conflicts
+			if (FuncGraph != nullptr) {
+				FBlueprintEditorUtils::RemoveGraph(Blueprint, FuncGraph, EGraphRemoveFlags::MarkTransient);
+				continue;
+			}
+
+			UEdGraph* NewGraph;
+			if(bIsAnimFunction) {
+				NewGraph = FBlueprintEditorUtils::CreateNewGraph(Blueprint, FunctionName, UAnimationGraph::StaticClass(), UAnimationGraphSchema::StaticClass());
+			} else {
+				NewGraph = FBlueprintEditorUtils::CreateNewGraph(Blueprint, FunctionName, UEdGraph::StaticClass(), UEdGraphSchema_K2::StaticClass());
+			}
+			
+			NewGraph->bAllowDeletion = false;
+			NewGraph->InterfaceGuid = FBlueprintEditorUtils::FindInterfaceFunctionGuid(Function, InterfaceClass);
+			NewInterface.Graphs.Add(NewGraph);
+			
+			FBlueprintEditorUtils::AddInterfaceGraph(Blueprint, NewGraph, InterfaceClass);
+		}
+	}
+
+	Blueprint->ImplementedInterfaces.Add(NewInterface);
+	return true;
+}
+
+bool FBlueprintGeneratorUtils::CreateParentFunctionCall(UBlueprint* Blueprint, UFunction* Function, UK2Node* FunctionEntryOrEventNode, UK2Node_FunctionResult* FunctionReturnNode) {
+	UFunction* CallableParentFunction = Blueprint->ParentClass->FindFunctionByName(Function->GetFName());
+
+	//We can get NULL if function in question is an interface function, in that case we don't have parent function to call
+	//Otherwise we should always get a valid function, since function passed should always come from one of parent classes original declaration
+	if (CallableParentFunction == NULL) {
+		return false;
+	}
+
+	//Spawn parent function call node and set it's function, plus allocate default pins
+	UEdGraph* TargetGraph = FunctionEntryOrEventNode->GetGraph();
+	const UEdGraphSchema_K2* GraphSchema = CastChecked<UEdGraphSchema_K2>(TargetGraph->GetSchema());
+	
+	FGraphNodeCreator<UK2Node_CallParentFunction> FunctionNodeCreator(*TargetGraph);
+	
+	UK2Node_CallParentFunction* ParentFunctionNode = FunctionNodeCreator.CreateNode();
+	ParentFunctionNode->SetFromFunction(CallableParentFunction);
+	ParentFunctionNode->AllocateDefaultPins();
+
+	const int32 NewNodeSpawnOffset = 400;
+	ParentFunctionNode->NodePosX = FunctionEntryOrEventNode->NodePosX + NewNodeSpawnOffset;
+	ParentFunctionNode->NodePosY = FunctionEntryOrEventNode->NodePosY;
+	FunctionNodeCreator.Finalize();
+	
+	//Move function result node to actually match location of newly spawned parent call node
+	if (FunctionReturnNode) {
+		FunctionReturnNode->NodePosX = FunctionEntryOrEventNode->NodePosX + NewNodeSpawnOffset * 2;
+		FunctionReturnNode->NodePosY = FunctionEntryOrEventNode->NodePosY;
+	}
+
+	//Connect parent function pins
+	for (UEdGraphPin* ParentPin : ParentFunctionNode->Pins) {
+		
+		//Skip all hidden pins we encounter, they will be filled by kismet compiler automatically
+		if (ParentPin->bHidden) {
+			continue;
+		}
+
+		//Output pins we always want to connect with the function result node
+		if (ParentPin->Direction == EGPD_Output) {
+		
+			//Connect Then pin with the Execute pin of the function result node if we have any
+			if (UEdGraphSchema_K2::IsExecPin(*ParentPin)) {
+				if (FunctionReturnNode) {
+					UEdGraphPin* ReturnNodeExecInputPin = GraphSchema->FindExecutionPin(*FunctionReturnNode, EGPD_Input);
+					ParentPin->MakeLinkTo(ReturnNodeExecInputPin);
+				}
+				continue;
+			}
+
+			//Otherwise we should try to find corresponding pin on the function return node
+			if (FunctionReturnNode) {
+				UEdGraphPin* ReturnInputPin = FunctionReturnNode->FindPin(ParentPin->PinName, EGPD_Input);
+				
+				if (ReturnInputPin) {
+					ReturnInputPin->BreakAllPinLinks(true);
+					ReturnInputPin->MakeLinkTo(ParentPin);
+				}
+			}
+
+		//Input pins we connect with function entry or event node
+		} else if (ParentPin->Direction == EGPD_Input) {
+
+			//Connect parent call exec pin with the then pin of the function entry
+			if (UEdGraphSchema_K2::IsExecPin(*ParentPin)) {
+				UEdGraphPin* FunctionEntryThenPin = GraphSchema->FindExecutionPin(*FunctionEntryOrEventNode, EGPD_Output);
+				
+				if (FunctionEntryThenPin) {
+					FunctionEntryThenPin->BreakAllPinLinks(true);
+					FunctionEntryThenPin->MakeLinkTo(ParentPin);
+				}
+				continue;
+			}
+
+			//Otherwise try to find entry pin matching our input pin name
+			UEdGraphPin* FunctionEntryPin = FunctionEntryOrEventNode->FindPin(ParentPin->PinName, EGPD_Output);
+			if (FunctionEntryPin) {
+				FunctionEntryPin->MakeLinkTo(ParentPin);
+			}
+		}
+	}
+	return true;
+}
+
+UK2Node_Event* FBlueprintGeneratorUtils::CreateCustomEventNode(UBlueprint* Blueprint, const FName& EventName) {
+	//Find all event nodes inside of the ubergraph
+	TArray<UK2Node_Event*> AllEventNodes;
+	for (const UEdGraph* Graph : Blueprint->UbergraphPages) {
+		Graph->GetNodesOfClass(AllEventNodes);
+	}
+
+	//Make effort to find existing event node first
+	for (UK2Node_Event* EventNode : AllEventNodes) {
+		if (EventNode->GetFunctionName() == EventName) {
+			return EventNode;
+		}
+	}
+
+	//We cannot really create any events without event graph
+	UEdGraph* EventGraph = FBlueprintEditorUtils::FindEventGraph(Blueprint);
+	if (!EventGraph) {
+		return NULL;
+	}
+
+	//Allocate node and set custom function name
+	FGraphNodeCreator<UK2Node_CustomEvent> NodeCreator(*EventGraph);
+	UK2Node_CustomEvent* CustomEventNode = NodeCreator.CreateNode();
+	CustomEventNode->CustomFunctionName = EventName;
+	CustomEventNode->bIsEditable = true;
+
+	const FVector2D GoodPlaceForNode = EventGraph->GetGoodPlaceForNewNode();
+	CustomEventNode->NodePosX = GoodPlaceForNode.X;
+	CustomEventNode->NodePosY = GoodPlaceForNode.Y;
+	
+	NodeCreator.Finalize();
+	return CustomEventNode;
+}
+
+UK2Node_FunctionResult* FBlueprintGeneratorUtils::CreateFunctionResultNode(const UK2Node_FunctionEntry* FunctionEntry, bool bAutoConnectNode) {
+	UEdGraph* Graph = FunctionEntry->GetGraph();
+	const UEdGraphSchema_K2* GraphSchema = CastChecked<UEdGraphSchema_K2>(Graph->GetSchema());
+	FGraphNodeCreator<UK2Node_FunctionResult> NodeCreator(*Graph);
+	
+	UK2Node_FunctionResult* ReturnNode = NodeCreator.CreateNode();
+	ReturnNode->FunctionReference = FunctionEntry->FunctionReference;
+	ReturnNode->NodePosX = FunctionEntry->NodePosX + FunctionEntry->NodeWidth + 256;
+	ReturnNode->NodePosY = FunctionEntry->NodePosY;
+	NodeCreator.Finalize();
+
+	const UFunction* FunctionSignature = FunctionEntry->FindSignatureFunction();
+	ReturnNode->CreateUserDefinedPinsForFunctionEntryExit(FunctionSignature, false);
+
+	//Auto-connect execution pins if we have been asked to
+	if (bAutoConnectNode) {
+		UEdGraphPin* EntryNodeExec = GraphSchema->FindExecutionPin(*FunctionEntry, EGPD_Output);
+		UEdGraphPin* ResultNodeExec = GraphSchema->FindExecutionPin(*ReturnNode, EGPD_Input);
+
+		EntryNodeExec->BreakAllPinLinks(true);
+		EntryNodeExec->MakeLinkTo(ResultNodeExec);
+	}
+	return ReturnNode;
+}
+
+UK2Node_FunctionEntry* FBlueprintGeneratorUtils::CreateFunctionGraph(UBlueprint* Blueprint, const FName& FunctionName) {
+	//If we already have a function graph with the same name, return function from it
+	if (const UEdGraph* ExistingGraph = FindObject<UEdGraph>(Blueprint, *FunctionName.ToString())) {
+		TArray<UK2Node_FunctionEntry*> FunctionEntries;
+		ExistingGraph->GetNodesOfClass(FunctionEntries);
+		
+		return FunctionEntries[0];
+	}
+	
+	UEdGraph* NewGraph = FBlueprintEditorUtils::CreateNewGraph(Blueprint, FunctionName, UEdGraph::StaticClass(), UEdGraphSchema_K2::StaticClass());
+	const UEdGraphSchema_K2* GraphSchema = CastChecked<const UEdGraphSchema_K2>(NewGraph->GetSchema());
+
+	//Create default graph nodes for a new function graph
+	GraphSchema->CreateDefaultNodesForGraph(*NewGraph);
+	GraphSchema->CreateFunctionGraphTerminators(*NewGraph, (UClass*) NULL);
+
+	//Add default function flags for kismet function, since we do not inherit any flags from parent function
+	int32 ExtraFunctionFlags = FUNC_BlueprintCallable | FUNC_BlueprintEvent | FUNC_Public;
+	if (Blueprint->BlueprintType == BPTYPE_FunctionLibrary) {
+		ExtraFunctionFlags |= FUNC_Static;
+	}
+	GraphSchema->AddExtraFunctionFlags(NewGraph, ExtraFunctionFlags);
+	
+	//Mark function entry as editable because it's a custom function and not an override
+	GraphSchema->MarkFunctionEntryAsEditable(NewGraph, true);
+	Blueprint->FunctionGraphs.Add(NewGraph);
+
+	TArray<UK2Node_FunctionEntry*> FunctionEntries;
+	NewGraph->GetNodesOfClass(FunctionEntries);
+	return FunctionEntries[0];
+}
+
+UK2Node* FBlueprintGeneratorUtils::CreateFunctionOverride(UBlueprint* Blueprint, UFunction* Function, bool bOverrideAsEvent, bool bCreateParentCall) {
+	const FName FunctionName = Function->GetFName();
+	UClass* FunctionOwnerClass = Function->GetOuterUClass()->GetAuthoritativeClass();
+	
+	UEdGraph* EventGraph = FBlueprintEditorUtils::FindEventGraph(Blueprint);
+	
+	//Attempt to implement function as event if we can, have event graph and it's desired
+	if (UEdGraphSchema_K2::FunctionCanBePlacedAsEvent(Function) && EventGraph && bOverrideAsEvent) {
+	
+		//Return existing event node first, in case of us having it already
+		UK2Node_Event* ExistingNode = FBlueprintEditorUtils::FindOverrideForFunction(Blueprint, FunctionOwnerClass, FunctionName);
+
+		//If it's a ghost node, we want to remove the ghost mark and create the parent call if it doesn't have one already
+		if (ExistingNode != NULL && ExistingNode->IsAutomaticallyPlacedGhostNode()) {
+			ResetNodeDisabledState(ExistingNode);
+			
+			UEdGraphPin* ExecPin = ExistingNode->FindPin(UEdGraphSchema_K2::PN_Then, EGPD_Output);
+			if (ExecPin == NULL) {
+				return ExistingNode;
+			}
+			
+			if (ExecPin->HasAnyConnections()) {
+				//If we have connections, we want to determine all of the connected nodes and make sure none of them is marked as disabled
+				for (const UEdGraphPin* ConnectedPin : ExecPin->LinkedTo) {
+					UEdGraphNode* OwningNode = ConnectedPin->GetOwningNode();
+						
+					if (OwningNode->IsAutomaticallyPlacedGhostNode()) {
+						ResetNodeDisabledState(OwningNode);
+					}
+				}
+			} else {
+				//If exec pin is not connected to anything, we actually want to create the parent call node normally
+				if (bCreateParentCall) {
+					CreateParentFunctionCall(Blueprint, Function, ExistingNode, NULL);
+				}
+			}
+		}
+
+		//If node exists and it's not a ghost node, we just return early
+		if (ExistingNode) {
+			return ExistingNode;
+		}
+		
+		UK2Node_Event* Event = FEdGraphSchemaAction_K2NewNode::SpawnNode<UK2Node_Event>(EventGraph, EventGraph->GetGoodPlaceForNewNode(), EK2NewNodeFlags::None,
+			[&](UK2Node_Event* NewInstance){
+        	NewInstance->EventReference.SetExternalMember(FunctionName, FunctionOwnerClass);
+        	NewInstance->bOverrideFunction = true;
+        });
+
+		if (bCreateParentCall) {
+			CreateParentFunctionCall(Blueprint, Function, Event, NULL);
+		}
+		return Event;
+	}
+
+	//Otherwise create function override using separate graph
+	//Returning existing function node if we already have an override
+	if (const UEdGraph* ExistingGraph = FindObject<UEdGraph>(Blueprint, *FunctionName.ToString())) {
+		TArray<UK2Node_FunctionEntry*> FunctionEntries;
+		ExistingGraph->GetNodesOfClass(FunctionEntries);
+		
+		return FunctionEntries[0];
+	}
+		
+	//Implement the function graph and spawn default nodes
+	UEdGraph* NewGraph = FBlueprintEditorUtils::CreateNewGraph(Blueprint, FunctionName, UEdGraph::StaticClass(), UEdGraphSchema_K2::StaticClass());
+	const UEdGraphSchema_K2* GraphSchema = CastChecked<const UEdGraphSchema_K2>(NewGraph->GetSchema());
+	
+	GraphSchema->CreateDefaultNodesForGraph(*NewGraph);
+	GraphSchema->CreateFunctionGraphTerminators(*NewGraph, FunctionOwnerClass);
+	
+	Blueprint->FunctionGraphs.Add(NewGraph);
+
+	UK2Node_FunctionEntry* FunctionEntry = NULL;
+	UK2Node_FunctionResult* FunctionResult = NULL;
+
+	//Find function entry and result nodes
+	for (UEdGraphNode* GraphNode : NewGraph->Nodes) {
+		if (UK2Node_FunctionEntry* Entry = Cast<UK2Node_FunctionEntry>(GraphNode)) {
+			FunctionEntry = Entry;
+		}
+		if (UK2Node_FunctionResult* Result = Cast<UK2Node_FunctionResult>(GraphNode)) {
+			FunctionResult = Result;
+		}
+	}
+	checkf(FunctionEntry, TEXT("K2Node_FunctionEntry not found on newly created function graph"));
+
+	//Make parent function call if we've been asked to
+	if (bCreateParentCall) {
+		CreateParentFunctionCall(Blueprint, Function, FunctionEntry, FunctionResult);
+	}
+	return FunctionEntry;
+}
+
+FName FBlueprintGeneratorUtils::GetFunctionNameForNode(UK2Node* Node) {
+	if (const UK2Node_Event* Event = Cast<UK2Node_Event>(Node)) {
+		return Event->GetFunctionName();
+	}
+	if (const UK2Node_FunctionEntry* FunctionEntry = Cast<UK2Node_FunctionEntry>(Node)) {
+		return FunctionEntry->CustomGeneratedFunctionName != NAME_None ? FunctionEntry->CustomGeneratedFunctionName : FunctionEntry->GetGraph()->GetFName();
+	}
+	return NAME_None;
+}
+
+UFunction* FBlueprintGeneratorUtils::FindFunctionInParentClassOrInterfaces(UBlueprint* Blueprint, const FName& FunctionName) {
+	//Attempt to find function inside of the implemented interfaces first
+	UFunction* ResultFunction = FBlueprintEditorUtils::GetInterfaceFunction(Blueprint, FunctionName);
+
+	//Search up the class hierarchy, we want to find the original declaration of the function
+	//because that way we do not depend on overrides being removed or added, and also match the behavior of original BP editor
+	if (ResultFunction == NULL) {
+		const UClass* ParentClass = Blueprint->ParentClass;
+
+		const UClass* CurrentClass = ParentClass->GetSuperClass();
+		ResultFunction = ParentClass->FindFunctionByName(FunctionName);
+		
+		while (CurrentClass != NULL && ResultFunction != NULL) {
+			if (UFunction* ParentFunction = CurrentClass->FindFunctionByName(FunctionName)) {
+				ResultFunction = ParentFunction;
+			} else {
+				break;
+			}
+			CurrentClass = CurrentClass->GetSuperClass();
+		}
+	}
+	return ResultFunction;
+}
+
+
+bool FBlueprintGeneratorUtils::CreateNewBlueprintFunctions(UBlueprint* Blueprint, const TArray<FDeserializedFunction>& Functions, const TFunctionRef<bool(const FDeserializedFunction& Function)>& FunctionFilter, bool bCreateFunctionOverrides) {
+	TSet<FName> ObsoleteBlueprintFunctions;
+	bool bChangedFunctionsOrParameters = false;
+
+	//Map all existing functions to their names, taking into account both function overrides and events
+	TMap<FName, UK2Node_EditablePinBase*> FunctionAndEventNodes;
+
+	TArray<UEdGraph*> AllBlueprintGraphs;
+	Blueprint->GetAllGraphs(AllBlueprintGraphs);
+
+	for (UEdGraph* Graph : AllBlueprintGraphs) {
+		for (UEdGraphNode* GraphNode : Graph->Nodes) {
+			if (UK2Node_Event* Event = Cast<UK2Node_Event>(GraphNode)) {
+				FunctionAndEventNodes.Add(Event->GetFunctionName(), Event);
+			}
+			if (UK2Node_FunctionEntry* FunctionEntry = Cast<UK2Node_FunctionEntry>(GraphNode)) {
+				FunctionAndEventNodes.Add(GetFunctionNameForNode(FunctionEntry), FunctionEntry);
+			}
+		}
+	}
+
+	//Populate a list of existing functions and events in the blueprint
+	TArray<FName> ObsoleteFunctionNames;
+	FunctionAndEventNodes.GetKeys(ObsoleteFunctionNames);
+	
+	//Create new functions and make sure signature of existing ones matches
+	for (const FDeserializedFunction& Function : Functions) {
+		ObsoleteFunctionNames.Add(Function.FunctionName);
+
+		//Discard functions that are generated, e.g. ubergraph
+		if (IsFunctionNameGenerated(Function.FunctionName.ToString())) {
+			continue;
+		}
+		//Discard functions that don't pass property filter
+		if (!FunctionFilter(Function)) {
+			continue;
+		}
+
+		//Determine whenever we're dealing with function override or new function
+		UFunction* OverridenFunction = FindFunctionInParentClassOrInterfaces(Blueprint, Function.FunctionName);
+
+		//If we're overriding a function, then we do not actually need to do anything except than checking that override exists
+		if (OverridenFunction) {
+			UK2Node_EditablePinBase* const* FunctionImplementation = FunctionAndEventNodes.Find(Function.FunctionName);
+
+			//We want to create the override even if function exists, but it's actually a ghost node
+			if ((FunctionImplementation == NULL || (*FunctionImplementation)->IsAutomaticallyPlacedGhostNode()) && bCreateFunctionOverrides) {
+				const bool bShouldGenerateAsEvent = Function.bIsCallingIntoUbergraph && UEdGraphSchema_K2::FunctionCanBePlacedAsEvent(OverridenFunction);
+				
+				CreateFunctionOverride(Blueprint, OverridenFunction, bShouldGenerateAsEvent, true);
+				bChangedFunctionsOrParameters = true;
+			}
+			continue;
+		}
+		
+		//Try to find existing function entry or event first
+		UK2Node_EditablePinBase* FunctionEntryOrEventNode;
+		TArray<UK2Node_FunctionResult*> FunctionResultNodes;
+
+		//Try to find existing function or event node first
+		if (UK2Node_EditablePinBase* const* ExistingNode = FunctionAndEventNodes.Find(Function.FunctionName)) {
+			FunctionEntryOrEventNode = *ExistingNode;
+
+			//Retrieve function result nodes if we're dealing with function graph
+			if (const UK2Node_FunctionEntry* FunctionEntry = Cast<const UK2Node_FunctionEntry>(FunctionEntryOrEventNode)) {
+				FunctionEntry->GetGraph()->GetNodesOfClass(FunctionResultNodes);
+			}
+		} else {
+			const bool bShouldImplementAsEvent = Function.bIsCallingIntoUbergraph;
+			
+			if (!bShouldImplementAsEvent) {
+				//If we should create new function as an actual function graph, make sure to also create function result node
+				UK2Node_FunctionEntry* FunctionEntry = CreateFunctionGraph(Blueprint, Function.FunctionName);
+				FunctionEntryOrEventNode = FunctionEntry;
+				
+				//Create function result node if function has any output parameters
+				if (Function.HasAnyOutputParams()) {
+					UK2Node_FunctionResult* FunctionResult = CreateFunctionResultNode(FunctionEntry, true);
+					FunctionResultNodes.Add(FunctionResult);
+				}
+			} else {
+				//Implement function as event, event functions cannot really have function return nodes
+				FunctionEntryOrEventNode = CreateCustomEventNode(Blueprint, Function.FunctionName);
+			}
+			bChangedFunctionsOrParameters = true;
+		}
+
+		//Make sure we have all flags from the deserialized function
+		if (UK2Node_Event* EventNode = Cast<UK2Node_Event>(FunctionEntryOrEventNode)) {
+			if (EventNode->FunctionFlags != Function.FunctionFlags) {
+				
+				EventNode->FunctionFlags = (Function.FunctionFlags & ~FUNC_Native);
+				bChangedFunctionsOrParameters = true;
+			}
+		} else if (UK2Node_FunctionEntry* FunctionEntryNode = Cast<UK2Node_FunctionEntry>(FunctionEntryOrEventNode)) {
+			if (FunctionEntryNode->GetExtraFlags() != Function.FunctionFlags) {
+
+				FunctionEntryNode->SetExtraFlags(Function.FunctionFlags);
+				bChangedFunctionsOrParameters = true;
+			}
+		}
+
+		//Make sure parameters on the function declaration stay up to date
+		bChangedFunctionsOrParameters |= SetFunctionEntryParameters(FunctionEntryOrEventNode, Function, true);
+
+		//Update parameters on function result nodes if we have any
+		if (FunctionResultNodes.Num()) {
+			bChangedFunctionsOrParameters |= SetFunctionEntryParameters(FunctionResultNodes[0], Function, false);
+		}
+	}
+
+	//Remove functions we actually used to implement in the past but no longer do
+	for (const FName& ObsoleteFunctionName : ObsoleteBlueprintFunctions) {
+		UK2Node* ExistingFunctionNode = FunctionAndEventNodes.FindChecked(ObsoleteFunctionName);
+		UEdGraph* NodeGraph = ExistingFunctionNode->GetGraph();
+
+		//We can remove event nodes as long as they're located inside of the ubergraph
+		if (UK2Node_Event* EventNode = Cast<UK2Node_Event>(ExistingFunctionNode)) {
+			if (Blueprint->UbergraphPages.Contains(NodeGraph)) {
+				
+				FBlueprintEditorUtils::RemoveNode(Blueprint, EventNode, true);
+				bChangedFunctionsOrParameters = true;
+				continue;
+			}
+		}
+
+		//For function nodes, we need to remove entire graphs, but make sure they're function graphs beforehand
+		if (Cast<UK2Node_FunctionEntry>(ExistingFunctionNode)) {
+			if (Blueprint->FunctionGraphs.Contains(NodeGraph)) {
+				
+				FBlueprintEditorUtils::RemoveGraph(Blueprint, NodeGraph, EGraphRemoveFlags::MarkTransient);
+				bChangedFunctionsOrParameters = true;
+				continue;
+			}
+		}
+
+		//Log nodes we couldn't really delete because they are not located in any known places
+		UE_LOG(LogAssetGenerator, Error, TEXT("Couldn't delete obsolete function %s inside of the graph %s because Graph is not an ubergraph or function graph"),
+			*ObsoleteFunctionName.ToString(), *NodeGraph->GetPathName());
+	}
+
+	return bChangedFunctionsOrParameters;
+}
+
+bool FBlueprintGeneratorUtils::CreateBlueprintVariablesForProperties(UBlueprint* Blueprint, const TArray<FDeserializedProperty>& Properties,
+                                                                     const TMap<FName, FDeserializedFunction>& Functions, const TFunctionRef<bool(const FDeserializedProperty& Property)>& PropertyFilter) {
+	TSet<FName> ObsoleteBlueprintProperties;
+	bool bChangedProperties = false;
+
+	//Populate a list of all currently existing variables in the blueprint
+	for (const FBPVariableDescription& Desc : Blueprint->NewVariables) {
+		ObsoleteBlueprintProperties.Add(Desc.VarName);
+	}
+	
+	//Create new variables and update existing ones
+	for (const FDeserializedProperty& Property : Properties) {
+		ObsoleteBlueprintProperties.Remove(Property.PropertyName);
+
+		//Discard properties that are 100% kismet compiler generated
+		if (IsPropertyNameGenerated(Property.PropertyName.ToString())) {
+			continue;
+		}
+		//Discard variables that didn't pass the provided property filter
+		if (PropertyFilter(Property)) {
+			continue;
+		}
+		
+		//Try to find existing variable using it's name
+		FBPVariableDescription* VariableDescription = FindBlueprintVariableByName(Blueprint, Property.PropertyName);
+
+		//Create new variable if we didn't find existing one
+		if (VariableDescription == NULL) {
+			VariableDescription = &Blueprint->NewVariables.AddDefaulted_GetRef();
+
+			VariableDescription->VarName = Property.PropertyName;
+			VariableDescription->VarGuid = FGuid::NewGuid();
+			VariableDescription->FriendlyName = Property.PropertyName.ToString();
+			
+			VariableDescription->Category = UEdGraphSchema_K2::VR_DefaultCategory;
+			VariableDescription->SetMetaData(TEXT("MultiLine"), TEXT("true"));
+			bChangedProperties = true;
+		} 
+
+		//Apply data to the variable description
+		if (VariableDescription->VarType != Property.GraphPinType) {
+			VariableDescription->VarType = Property.GraphPinType;
+			bChangedProperties = true;
+		}
+		
+		if (VariableDescription->PropertyFlags != (uint64) Property.PropertyFlags) {
+			VariableDescription->PropertyFlags = (uint64) Property.PropertyFlags;
+			bChangedProperties = true;
+		}
+		
+		if (VariableDescription->RepNotifyFunc != Property.RepNotifyFunc) {
+			VariableDescription->RepNotifyFunc = Property.RepNotifyFunc;
+			bChangedProperties = true;
+		}
+		
+		if (VariableDescription->ReplicationCondition != Property.BlueprintReplicationCondition) {
+			VariableDescription->ReplicationCondition = Property.BlueprintReplicationCondition;
+			bChangedProperties = true;
+		}
+		
+		//Make sure multicast delegates actually have valid graphs
+		if (VariableDescription->VarType.PinCategory == UEdGraphSchema_K2::PC_MCDelegate) {
+			UEdGraph* DelegateSignatureGraph = FBlueprintEditorUtils::GetDelegateSignatureGraphByName(Blueprint, VariableDescription->VarName);
+			
+			if (DelegateSignatureGraph == NULL) {
+				DelegateSignatureGraph = CreateNewBlueprintEventDispatcherSignatureGraph(Blueprint, VariableDescription->VarName);
+			}
+
+			//Make sure delegate function parameters are up to date
+			TArray<UK2Node_FunctionEntry*> FunctionEntries;
+			DelegateSignatureGraph->GetNodesOfClass(FunctionEntries);
+			check(FunctionEntries.Num());
+
+			const FString DelegateSignatureFunctionName = FString::Printf(TEXT("%s%s"), *VariableDescription->VarName.ToString(), HEADER_GENERATED_DELEGATE_SIGNATURE_SUFFIX);
+			const FDeserializedFunction& DelegateSignature = Functions.FindChecked(*DelegateSignatureFunctionName);
+			
+			if (SetFunctionEntryParameters(FunctionEntries[0], DelegateSignature, true)) {
+				bChangedProperties = true;
+			}
+		}
+	}
+
+	if (ObsoleteBlueprintProperties.Num()) {
+		bChangedProperties = true;
+	}
+
+	//Remove delegate signature graphs for obsolete properties
+	TArray<UEdGraph*> ObsoleteDelegateSignatureGraphs;
+	
+	for (UEdGraph* DelegateSignatureGraph : Blueprint->DelegateSignatureGraphs) {
+		if (ObsoleteBlueprintProperties.Contains(DelegateSignatureGraph->GetFName())) {
+			ObsoleteDelegateSignatureGraphs.Add(DelegateSignatureGraph);
+		}
+	}
+	for (UEdGraph* DelegateSignatureGraph : ObsoleteDelegateSignatureGraphs) {
+		FBlueprintEditorUtils::RemoveGraph(Blueprint, DelegateSignatureGraph, EGraphRemoveFlags::MarkTransient);
+	}
+	
+	//Remove obsolete variables descriptors
+	Blueprint->NewVariables.RemoveAll([&](const FBPVariableDescription& Desc){
+		return ObsoleteBlueprintProperties.Contains(Desc.VarName);
+	});
+	return bChangedProperties;
+}
+
+bool FBlueprintGeneratorUtils::SetFunctionEntryParameters(UK2Node_EditablePinBase* FunctionEntry, const FDeserializedFunction& Function, bool bIsFunctionEntry) {
+	TArray<FDeserializedProperty> ParameterArray;
+
+	//Collect all parameters matching our input parameter boolean (because we can be dealing with function result node instead)
+	for (const FDeserializedProperty& Parameter : Function.Parameters) {
+		if (Parameter.IsFunctionInputParam() == bIsFunctionEntry) {
+			ParameterArray.Add(Parameter);
+		}
+	}
+	
+	const TArray<TSharedPtr<FUserPinInfo>> OldUserDefinedPins = FunctionEntry->UserDefinedPins;
+	bool bNeedToDeleteExistingPins = false;
+	
+	for (int32 i = 0; i < OldUserDefinedPins.Num(); i++) {
+		//Cleanup properties if there are more of them than we expect
+		if (!ParameterArray.IsValidIndex(i)) {
+			bNeedToDeleteExistingPins = true;
+			break;
+		}
+
+		const TSharedPtr<FUserPinInfo>& UserPinInfo = OldUserDefinedPins[i];
+		const FDeserializedProperty& Property = ParameterArray[i];
+
+		//Cleanup properties if names or pin types of one of them do not match
+		if (UserPinInfo->PinName != Property.PropertyName ||
+			UserPinInfo->PinType != Property.GraphPinType) {
+			bNeedToDeleteExistingPins = true;
+			break;
+		}
+
+		//TEMPFIX: If current user pins have the invalid __WorldContext pin generated, we need to regenerate pins
+		if (UserPinInfo->PinName == TEXT("__WorldContext")) {
+			bNeedToDeleteExistingPins = true;
+			break;
+		}
+	}
+	
+	//Cleanup pins if we need to because they overlap with new ones
+	if (bNeedToDeleteExistingPins) {
+		for (const TSharedPtr<FUserPinInfo>& UserPinInfo : OldUserDefinedPins) {
+			FunctionEntry->RemoveUserDefinedPin(UserPinInfo);
+		}
+	}
+
+	//Add new pins, but skip over the ones we already have except if we cleaned them up
+	const int32 FirstPinIndex = bNeedToDeleteExistingPins ? 0 : OldUserDefinedPins.Num();
+	
+	for (int32 i = FirstPinIndex; i < ParameterArray.Num(); i++) {
+		const FDeserializedProperty& Property = ParameterArray[i];
+
+		//Skip the pin if it represents a compiler-generated world context pin
+		if (Property.PropertyName != TEXT("__WorldContext")) {
+			FunctionEntry->CreateUserDefinedPin(Property.PropertyName, Property.GraphPinType, EGPD_Output);	
+		}
+	}
+
+	//We have changed something as long as first pin index is not the last one
+	return FirstPinIndex != ParameterArray.Num();
+}
+
+UEdGraph* FBlueprintGeneratorUtils::CreateNewBlueprintEventDispatcherSignatureGraph(UBlueprint* Blueprint, const FName& DispatcherName) {
+	const UEdGraphSchema_K2* K2Schema = GetDefault<UEdGraphSchema_K2>();
+	
+	UEdGraph* NewGraph = FBlueprintEditorUtils::CreateNewGraph(Blueprint, DispatcherName, UEdGraph::StaticClass(), UEdGraphSchema_K2::StaticClass());
+	checkf(NewGraph, TEXT("Failed to create new graph %s for Event Dispatcher in BLueprint %s"), *DispatcherName.ToString(), *Blueprint->GetPathName());
+	
+	NewGraph->bEditable = false;
+	K2Schema->CreateDefaultNodesForGraph(*NewGraph);
+	K2Schema->CreateFunctionGraphTerminators(*NewGraph, (UClass*) NULL);
+	
+	K2Schema->AddExtraFunctionFlags(NewGraph, FUNC_BlueprintCallable | FUNC_BlueprintEvent | FUNC_Public);
+	K2Schema->MarkFunctionEntryAsEditable(NewGraph, true);
+
+	Blueprint->DelegateSignatureGraphs.Add(NewGraph);
+	return NewGraph;
+}
+
+FBPVariableDescription* FBlueprintGeneratorUtils::FindBlueprintVariableByName(UBlueprint* Blueprint, const FName& VariableName) {
+	for (FBPVariableDescription& VariableDescription : Blueprint->NewVariables) {
+		if (VariableDescription.VarName == VariableName) {
+			return &VariableDescription;
+		}
+	}
+	return NULL;
+}
+
+void FBlueprintGeneratorUtils::ResetNodeDisabledState(UEdGraphNode* GraphNode) {
+	GraphNode->SetEnabledState(ENodeEnabledState::Enabled, true);
+	GraphNode->bCommentBubblePinned = false;
+	GraphNode->bCommentBubbleVisible = false;
+	GraphNode->NodeComment = TEXT("");
+}
+*/

--- a/AssetGenerator/Source/AssetGenerator/Private/Toolkit/AssetTypeGenerator/AnimBlueprintGenerator.cpp
+++ b/AssetGenerator/Source/AssetGenerator/Private/Toolkit/AssetTypeGenerator/AnimBlueprintGenerator.cpp
@@ -312,6 +312,8 @@ FName UAnimBlueprintGenerator::GetAssetClass() {
 	return UAnimBlueprint::StaticClass()->GetFName();
 }
 
+#undef LOCTEXT_NAMESPACE
+
 /*
 //Never generate __DelegateSignature methods, they are automatically handled
 //ExecuteUbergraph methods should also never be generated, since they have corresponding function entries

--- a/AssetGenerator/Source/AssetGenerator/Private/Toolkit/AssetTypeGenerator/BlueprintGenerator.cpp
+++ b/AssetGenerator/Source/AssetGenerator/Private/Toolkit/AssetTypeGenerator/BlueprintGenerator.cpp
@@ -1047,3 +1047,5 @@ void FBlueprintGeneratorUtils::ResetNodeDisabledState(UEdGraphNode* GraphNode) {
 	GraphNode->bCommentBubbleVisible = false;
 	GraphNode->NodeComment = TEXT("");
 }
+
+#undef LOCTEXT_NAMESPACE

--- a/AssetGenerator/Source/AssetGenerator/Private/Toolkit/AssetTypeGenerator/MaterialGenerator.cpp
+++ b/AssetGenerator/Source/AssetGenerator/Private/Toolkit/AssetTypeGenerator/MaterialGenerator.cpp
@@ -26,6 +26,7 @@
 #include "VT/RuntimeVirtualTexture.h"
 #include "Engine/TextureCube.h"
 #include "Materials/MaterialExpressionTextureSampleParameter2DArray.h"
+#include "MediaTexture.h"
 
 static const TArray<FName> ExcludedMaterialDumpProperties = {
 	//We cannot recompile game materials and add usages since we do not have their sources, so we ignore this value and force it to false
@@ -240,7 +241,7 @@ void UMaterialGenerator::ConnectBasicParameterPinsIfPossible(UMaterial* Material
 }
 
 UClass* GetTextureSampleParameterClassForTexture(UTexture* Texture) {
-	if (Texture->IsA<UTexture2D>()) {
+	if (Texture->IsA<UTexture2D>() || Texture->IsA<UMediaTexture>()) {
 		return UMaterialExpressionTextureSampleParameter2D::StaticClass();
 	}
 	if (Texture->IsA<UTextureCube>()) {

--- a/AssetGenerator/Source/AssetGenerator/Private/Toolkit/AssetTypeGenerator/MaterialInstanceGenerator.cpp
+++ b/AssetGenerator/Source/AssetGenerator/Private/Toolkit/AssetTypeGenerator/MaterialInstanceGenerator.cpp
@@ -50,6 +50,7 @@ FStaticParameterSet UMaterialInstanceGenerator::GetStaticParameterOverrides() co
 }
 
 void UMaterialInstanceGenerator::PopulateStageDependencies(TArray<FPackageDependency>& AssetDependencies) const {
+	if (GetAssetData()->GetBoolField(TEXT("SkipDependecies"))) return;
 	if (GetCurrentStage() == EAssetGenerationStage::CONSTRUCTION) {
 		const TSharedPtr<FJsonObject> AssetData = GetAssetData();
 		const TSharedPtr<FJsonObject> AssetObjectProperties = AssetData->GetObjectField(TEXT("AssetObjectData"));

--- a/AssetGenerator/Source/AssetGenerator/Private/Toolkit/AssetTypeGenerator/PhysicalMaterialGenerator.cpp
+++ b/AssetGenerator/Source/AssetGenerator/Private/Toolkit/AssetTypeGenerator/PhysicalMaterialGenerator.cpp
@@ -1,5 +1,6 @@
 #include "Toolkit/AssetTypeGenerator/PhysicalMaterialGenerator.h"
 #include "PhysicalMaterials/PhysicalMaterial.h"
+#include "Dom/JsonObject.h"
 
 UClass* UPhysicalMaterialGenerator::GetAssetObjectClass() const {
 	return UPhysicalMaterial::StaticClass();
@@ -8,3 +9,12 @@ UClass* UPhysicalMaterialGenerator::GetAssetObjectClass() const {
 FName UPhysicalMaterialGenerator::GetAssetClass() {
 	return UPhysicalMaterial::StaticClass()->GetFName();
 }
+
+//UClass* UPhysicalMaterialGenerator::GetAssetObjectClass() const {
+//	const FString AssetClassPath = GetAssetData()->GetStringField(TEXT("AssetClass"));
+//	return FindObjectChecked<UClass>(NULL, *AssetClassPath);
+//}
+//
+//FName UPhysicalMaterialGenerator::GetAssetClass() {
+//	return UPhysicalMaterial::StaticClass()->GetFName();
+//}

--- a/AssetGenerator/Source/AssetGenerator/Private/Toolkit/AssetTypeGenerator/SimpleAssetGen.cpp
+++ b/AssetGenerator/Source/AssetGenerator/Private/Toolkit/AssetTypeGenerator/SimpleAssetGen.cpp
@@ -1,0 +1,19 @@
+#include "Toolkit/AssetTypeGenerator/SimpleAssetGen.h"
+#include "Dom/JsonObject.h"
+
+UClass* USimpleAssetGen::GetAssetObjectClass() const {
+	const FString AssetClassPath = GetAssetData()->GetStringField(TEXT("AssetClass"));
+	return FindObjectChecked<UClass>(NULL, *AssetClassPath);
+}
+
+FName USimpleAssetGen::GetAssetClass() {
+	return TEXT("SimpleAsset"); //UPhysicalMaterial::StaticClass()->GetFName();
+}
+
+void USimpleAssetGen::PopulateStageDependencies(TArray<FPackageDependency>& OutDependencies) const {
+	if (!GetAssetData()->GetBoolField(TEXT("SkipDependecies"))) {
+		if (GetCurrentStage() == EAssetGenerationStage::CONSTRUCTION) {
+			PopulateReferencedObjectsDependencies(OutDependencies);
+		}
+	}
+}

--- a/AssetGenerator/Source/AssetGenerator/Private/Toolkit/AssetTypeGenerator/SoundCueGenerator.cpp
+++ b/AssetGenerator/Source/AssetGenerator/Private/Toolkit/AssetTypeGenerator/SoundCueGenerator.cpp
@@ -1,0 +1,100 @@
+#include "Toolkit/AssetTypeGenerator/SoundCueGenerator.h"
+
+#include "Framework/MultiBox/MultiBoxBuilder.h"
+#include "EdGraph/EdGraphNode.h"
+#include "Modules/ModuleManager.h"
+#include "EditorStyleSet.h"
+#include "SoundCueGraph/SoundCueGraph.h"
+#include "SoundCueGraph/SoundCueGraphNode.h"
+#include "SoundCueGraph/SoundCueGraphNode_Base.h"
+#include "SoundCueGraph/SoundCueGraphNode_Root.h"
+#include "SoundCueGraph/SoundCueGraphSchema.h"
+#include "Sound/SoundWave.h"
+#include "Sound/DialogueWave.h"
+#include "Sound/SoundCue.h"
+#include "Components/AudioComponent.h"
+#include "AudioEditorModule.h"
+#include "Sound/SoundNodeWavePlayer.h"
+#include "ScopedTransaction.h"
+#include "GraphEditor.h"
+#include "GraphEditorActions.h"
+#include "Kismet2/BlueprintEditorUtils.h"
+#include "EdGraphUtilities.h"
+#include "SNodePanel.h"
+#include "Editor.h"
+#include "SoundCueGraphEditorCommands.h"
+#include "PropertyEditorModule.h"
+#include "IDetailsView.h"
+#include "Widgets/Docking/SDockTab.h"
+#include "Framework/Commands/GenericCommands.h"
+#include "Sound/SoundNodeDialoguePlayer.h"
+#include "HAL/PlatformApplicationMisc.h"
+#include "AudioDeviceManager.h"
+#include "Audio/AudioDebug.h"
+#include <Editor/UnrealEd/Public/EdGraphUtilities.h>
+#include <Editor/GraphEditor/Public/SNodePanel.h>
+
+#include "Dom/JsonObject.h"
+#include <Editor/AudioEditor/Private/SoundCueEditor.h>
+
+UClass* USoundCueGenerator::GetAssetObjectClass()  const {
+	return USoundCue::StaticClass();
+}
+
+FName USoundCueGenerator::GetAssetClass() {
+	return USoundCue::StaticClass()->GetFName();
+}
+
+void USoundCueGenerator::CreateAssetPackage() {
+	UPackage* NewPackage = CreatePackage(*GetPackageName().ToString());
+	USoundCue* SoundCue = NewObject<USoundCue>(NewPackage, GetAssetName(), RF_Public | RF_Standalone);
+	SetPackageAndAsset(NewPackage, SoundCue);
+
+	SoundCue->GetGraph()->Modify();
+	SoundCue->Modify();
+
+	const FString TextToImport = GetAssetData()->GetStringField(TEXT("SoundCueGraph")).ReplaceEscapedCharWithChar();
+	
+	// Import the nodes
+	TSet<UEdGraphNode*> PastedNodes;
+	FEdGraphUtilities::ImportNodesFromText(SoundCue->GetGraph(), TextToImport, /*out*/ PastedNodes);
+
+
+
+	for (TSet<UEdGraphNode*>::TIterator It(PastedNodes); It; ++It)
+	{
+		UEdGraphNode* Node = *It;
+
+		if (USoundCueGraphNode* SoundGraphNode = Cast<USoundCueGraphNode>(Node))
+		{
+			SoundCue->AllNodes.Add(SoundGraphNode->SoundNode);
+		}
+
+		if (Node->NodePosX == 0 && Node->NodePosY == 0) {
+			for (UEdGraphNode* node : SoundCue->GetGraph()->Nodes)
+			{
+				if (USoundCueGraphNode_Root* root = Cast<USoundCueGraphNode_Root>(node)) {
+					Node->FindPin(TEXT("Output"), EGPD_Output)->MakeLinkTo(root->Pins[0]);
+				}
+			}
+			
+		}
+		Node->NodePosX = Node->NodePosX - 300;
+		Node->SnapToGrid(SNodePanel::GetSnapGridSize());
+
+		// Give new node a different Guid from the old one
+		Node->CreateNewGuid();
+	}
+
+	// Force new pasted SoundNodes to have same connections as graph nodes
+	SoundCue->CompileSoundNodesFromGraphNodes();
+
+	// Update UI
+	//SoundCueGraphEditor->NotifyGraphChanged();
+
+	SoundCue->PostEditChange();
+	SoundCue->MarkPackageDirty();
+
+
+	PopulateSimpleAssetWithData(SoundCue);
+}

--- a/AssetGenerator/Source/AssetGenerator/Private/Toolkit/AssetTypeGenerator/UserDefinedEnumGenerator.cpp
+++ b/AssetGenerator/Source/AssetGenerator/Private/Toolkit/AssetTypeGenerator/UserDefinedEnumGenerator.cpp
@@ -56,9 +56,12 @@ void UUserDefinedEnumGenerator::PopulateEnumWithData(UUserDefinedEnum* Enum) {
 	for (const TSharedPtr<FJsonValue> NameValue : DisplayNames) {
 		const TSharedPtr<FJsonObject> PairObject = NameValue->AsObject();
 		const FName Name = FName(*PairObject->GetStringField(TEXT("Name")));
-		const FString DisplayName = PairObject->GetStringField(TEXT("DisplayName"));
+		const FString DisplayNameJson = PairObject->GetStringField(TEXT("DisplayName"));
 
-		Enum->DisplayNameMap.Add(Name, FText::FromString(DisplayName));
+		FText DisplayName;
+		FTextStringHelper::ReadFromBuffer(*DisplayNameJson, DisplayName);
+
+		Enum->DisplayNameMap.Add(Name, DisplayName);
 	}
 
 	MarkAssetChanged();

--- a/AssetGenerator/Source/AssetGenerator/Private/Toolkit/AssetTypeGenerator/UserWidgetGenerator.cpp
+++ b/AssetGenerator/Source/AssetGenerator/Private/Toolkit/AssetTypeGenerator/UserWidgetGenerator.cpp
@@ -83,6 +83,12 @@ void UUserWidgetGenerator::FinalizeAssetCDO() {
 		}
 		WidgetBlueprint->Animations.Empty();
 
+		// Deserializing the animation will find these ones, so we move them to avoid that. The class will be regenerated afterwards anyway
+		UWidgetBlueprintGeneratedClass* GeneratedClass = Cast<UWidgetBlueprintGeneratedClass>(WidgetBlueprint->GeneratedClass);
+		for (UObject* AnimationObject : GeneratedClass->Animations) {
+			MoveToTransientPackageAndRename(AnimationObject);
+		}
+
 		//Deserialize new animations into the array directly
 		for (const TSharedPtr<FJsonValue>& Animation : Animations) {
 			UObject* AnimationObject = GetObjectSerializer()->DeserializeObject((int32) Animation->AsNumber());

--- a/AssetGenerator/Source/AssetGenerator/Public/Toolkit/AssetTypeGenerator/AnimBlueprintGenerator.h
+++ b/AssetGenerator/Source/AssetGenerator/Public/Toolkit/AssetTypeGenerator/AnimBlueprintGenerator.h
@@ -1,0 +1,24 @@
+﻿#pragma once
+#include "CoreMinimal.h"
+#include "Toolkit/AssetGeneration/AssetGenerationUtil.h"
+#include "Toolkit/AssetTypeGenerator/BlueprintGenerator.h"
+#include "Engine/Blueprint.h"
+#include "AnimBlueprintGenerator.generated.h"
+
+UCLASS()
+class ASSETGENERATOR_API UAnimBlueprintGenerator : public UBlueprintGenerator {
+GENERATED_BODY()
+protected:
+	//virtual void CreateAssetPackage() override;
+	//virtual void OnExistingPackageLoaded() override;
+
+	virtual UBlueprint* CreateNewBlueprint(UPackage* Package, UClass* ParentClass) override;
+	//virtual void PostConstructOrUpdateAsset(UBlueprint* Blueprint);
+	//virtual void PopulateAssetWithData() override;
+	//virtual void FinalizeAssetCDO() override;
+	//void UpdateDeserializerBlueprintClassObject(bool bRecompileBlueprint);
+	//virtual UClass* GetFallbackParentClass() const;
+public:
+	//virtual void PopulateStageDependencies(TArray<FPackageDependency>& OutDependencies) const override;
+	virtual FName GetAssetClass() override;
+};

--- a/AssetGenerator/Source/AssetGenerator/Public/Toolkit/AssetTypeGenerator/SimpleAssetGen.h
+++ b/AssetGenerator/Source/AssetGenerator/Public/Toolkit/AssetTypeGenerator/SimpleAssetGen.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "CoreMinimal.h"
+#include "Toolkit/AssetTypeGenerator/SimpleAssetGenerator.h"
+#include "SimpleAssetGen.generated.h"
+
+UCLASS(MinimalAPI)
+class USimpleAssetGen : public USimpleAssetGenerator {
+	GENERATED_BODY()
+protected:
+	virtual UClass* GetAssetObjectClass() const override;
+public:
+	virtual FName GetAssetClass() override;
+	virtual void PopulateStageDependencies(TArray<FPackageDependency>& OutDependencies) const override;
+};

--- a/AssetGenerator/Source/AssetGenerator/Public/Toolkit/AssetTypeGenerator/SimpleAssetGenerator.h
+++ b/AssetGenerator/Source/AssetGenerator/Public/Toolkit/AssetTypeGenerator/SimpleAssetGenerator.h
@@ -8,7 +8,7 @@ class ASSETGENERATOR_API USimpleAssetGenerator : public UAssetTypeGenerator {
 	GENERATED_BODY()
 protected:
 	virtual UClass* GetAssetObjectClass() const PURE_VIRTUAL(GetAssetObjectClass, return NULL;);
-	virtual void CreateAssetPackage() override final;
+	virtual void CreateAssetPackage() override;
 	virtual void OnExistingPackageLoaded() override final;
 	
 	virtual void PopulateSimpleAssetWithData(UObject* Asset);

--- a/AssetGenerator/Source/AssetGenerator/Public/Toolkit/AssetTypeGenerator/SoundCueGenerator.h
+++ b/AssetGenerator/Source/AssetGenerator/Public/Toolkit/AssetTypeGenerator/SoundCueGenerator.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "CoreMinimal.h"
+#include "Toolkit/AssetTypeGenerator/SimpleAssetGenerator.h"
+#include "SoundCueGenerator.generated.h"
+
+UCLASS(MinimalAPI)
+class USoundCueGenerator : public USimpleAssetGenerator {
+	GENERATED_BODY()
+protected:
+	virtual UClass* GetAssetObjectClass() const override;
+	virtual void CreateAssetPackage() override;
+public:
+	virtual FName GetAssetClass() override;
+};


### PR DESCRIPTION
*Note: This is being PRed from my fork of Narknon's fork of LW's fork for various reasons.*

- The sound cue generator generates the full cue graph (LW)
- The animBP generator only generates properties, and has a limitation that when opened in-editor, the skeleton needs to be manually assigned to it (LW)
- Simple asset gen is for generating assets like submixes, soundmixes, soundclasses, data assets, etc. (LW)
- Fixed many warnings (Narknon)